### PR TITLE
modernize, format, add tracing, adjust log levels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 description = "An implementation of the XMODEM file-transfer protocol."
 
 [dependencies]
-log = "^0.3"
+log = "^0.4.17"
 crc16 = "^0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Used in: https://github.com/orangecms/vf2-loader
Demo: https://twitter.com/OrangeCMS/status/1628844843949608961

Everything else: 
- `foo()?;` instead of `try!(foo());` as suggested by Clippy
- add `trace!()` for inidividual byte transfers (that helped...)
- raise some `debug!()` to `!info()`
- take returned transfer counts

EDIT:
I had initially raised the maximum error count from 16 to 32, but discarded that again.